### PR TITLE
Fix multi-word search relevance and add TMDb IDs for trailer support

### DIFF
--- a/browse.py
+++ b/browse.py
@@ -461,7 +461,7 @@ def search():
         return
     if page == 1:
         storage.save_to_search_history(search_string)
-    api_query = search_string.replace(' ', '_')
+    api_query = search_string
     cache_key = f"search_{api_query}_{page}"
     pDialog = xbmcgui.DialogProgressBG()
     pDialog.create('KodiSeerr', 'Fetching Results')

--- a/browse.py
+++ b/browse.py
@@ -467,7 +467,9 @@ def search():
     pDialog.create('KodiSeerr', 'Fetching Results')
     data = cache.get_cached(cache_key)
     if not data:
-        data = api_client.client.api_request('/search', params={'query': api_query, 'page': page})
+        from urllib.parse import urlencode, quote
+        qs = urlencode({'query': api_query, 'page': page}, quote_via=quote)
+        data = api_client.client.api_request(f'/search?{qs}', params=None)
         if data:
             cache.set_cached(cache_key, data)
     pDialog.update(50)

--- a/media_utils.py
+++ b/media_utils.py
@@ -83,11 +83,15 @@ def make_info(item, media_type):
         'studio': studio or "",
         'country': country or "",
         'mediatype': media_type,
+        'tmdb_id': item.get('id'),
     }
 
 
 def set_info_tag(list_item, info):
     tag = list_item.getVideoInfoTag()
+    if info.get('tmdb_id'):
+        try: tag.setUniqueIDs({'tmdb': str(info['tmdb_id'])}, 'tmdb')
+        except Exception: pass
     if info.get('title'): tag.setTitle(info['title'])
     if info.get('plot'): tag.setPlot(info['plot'])
     if info.get('year'):


### PR DESCRIPTION
## Summary

Three commits, two bug fixes and one small feature, all in the search → request UX flow:

1. **Fix:** drop the `replace(' ', '_')` substitution in `search()` that ships unrelated TMDb results to the user.
2. **Fix:** URL-encode the search query with `%20` (Python's `requests` defaults to `+`, which Jellyseerr's `/search` endpoint rejects with HTTP 400).
3. **Feature:** set TMDb `unique_ids` on list items so skin-side trailer/enrichment pipelines (TMDb Helper, Arctic Fuse 3, Embuary, …) can look the items up.

The two fixes together address the underlying cause of the still-effectively-broken search behaviour from issue #7 (closed); the metadata feature is related to #3 (closed) but is much more targeted than that issue's broader "make it look like TMDb Helper" request.

The three commits are intentionally separate so any one of them can be cherry-picked or reverted independently. The two `fix(search)` commits are designed to land together — commit 1 alone surfaces the latent encoding bug that commit 2 then resolves.

## Bug 1 — Search relevance is broken (closes the underlying #7)

The current code rewrites the query before sending it to Jellyseerr:

```python
api_query = search_string.replace(' ', '_')
```

This was introduced as a workaround so that multi-word searches stop returning HTTP 400 ("zero results" from the user's POV — closing #7). It does avoid the 400, but at the cost of correctness: TMDb then matches `star_wars` as a literal token, which puts unrelated, edge-case titles at the top of the results.

Reproducer with the current upstream behaviour:

```
search "star wars"
-> sent as `query=star_wars`
-> top results:
   1. Aussie StarWars!
   2. Aussie StarWars 2!
   3. Star Wars Detours
   ...
```

After this PR:

```
search "star wars"
-> sent as `query=star%20wars`
-> top results:
   1. Star Wars (1977)
   2. Star Wars: Visions
   3. Star Wars: The Clone Wars
   ...
```

This is the relevance ranking TMDb returns natively — what users expect.

## Bug 2 — HTTP 400 from Jellyseerr on every multi-word query

Once the underscore substitution is removed, every multi-word search fails:

```
HTTP 400 Bad Request
{
  "message": "Parameter 'query' must be url encoded. Its value may not contain reserved characters.",
  "errors": [{
    "path": ".query.query",
    "message": "Parameter 'query' must be url encoded. Its value may not contain reserved characters."
  }]
}
```

Root cause: Python's `requests` library form-encodes query parameters by default (spaces → `+`), but Jellyseerr's `/search` validates strictly per RFC 3986 and rejects `+`. Only `%20` is accepted.

Verified directly against a live Jellyseerr 2.x instance:

| Query parameter | HTTP | Result |
|---|---|---|
| `query=star%20wars` | **200** | 20 correct results (Star Wars, Visions, Clone Wars, …) |
| `query=star+wars`   | **400** | rejected with the message above |
| `query=star_wars`   | **200** | 20 unrelated results (the prior upstream behaviour) |

Fix: build the query string with `urlencode(..., quote_via=quote)` so spaces become `%20`, and pass it as part of the endpoint path with `params=None` to prevent `requests` from re-encoding.

The change is intentionally scoped to the `/search` call site — no other endpoint in the addon takes user-typed strings as query parameters today.

## Feature — TMDb unique IDs on list items (related to #3)

Skin-side enrichment pipelines (TMDb Helper, Arctic Fuse 3, Embuary, …) all key off `unique_ids.tmdb` on the Kodi list item to look up the title for trailers, extended cast, ratings, recommendations, fanart, etc. Previously KodiSeerr never set any unique IDs, so those pipelines had nothing to query. The info dialog had no working trailer button, and skins couldn't enrich the items further.

`grep -r "trailer" .` against the upstream addon returns zero hits, confirming this is an unimplemented feature rather than a regression.

The change is two lines in `media_utils.py`:

- `make_info()` exposes the upstream Jellyseerr/TMDb id as `tmdb_id` in the returned dict.
- `set_info_tag()` calls `tag.setUniqueIDs({'tmdb': ...}, 'tmdb')` when present, wrapped in a try/except for older Kodi versions where the call shape might differ.

The Jellyseerr API returns the TMDb id as `item['id']` for both movies and TV results, so this mapping is safe across every browse flow that goes through `make_info` / `set_info_tag`.

## Verification

End-to-end testing was done against a live Jellyseerr 2.x instance + a Kodi 21 Omega install (on CoreELEC) running the Arctic Fuse 3 skin, integrated via the Arctic Fuse 3 search panel:

- Multi-word searches (`star wars`, `the matrix`, `breaking bad`, …) now return TMDb's natural relevance ranking. No more "Aussie StarWars!" surprises.
- Multi-word searches no longer 400 against Jellyseerr.
- Single-word searches still work (no regression — the encoding still produces a valid query).
- Opening the info dialog on a search result populates the trailer button + extended TMDb-Helper-driven metadata as expected.

There is no upstream CI to run, but `python3 -c "import ast; ast.parse(...)"` was run on both modified files to catch any syntax errors before push.

## Test plan for the maintainer

- [ ] Search a multi-word query (e.g. "star wars") via Kodi → check top result is the original *Star Wars (1977)*, not "Aussie StarWars!"
- [ ] Search a multi-word query → no HTTP 400 in the Kodi log.
- [ ] Open info dialog on a search result → verify a `tmdb` unique id is present on the item (skin-dependent surface).
- [ ] If a TMDb-Helper-driven skin is in use → verify trailer + extended metadata populate.

Happy to iterate on naming, body content, or split into multiple PRs if preferred.
